### PR TITLE
Improve metadata types

### DIFF
--- a/src/Metadata/Collection/TypeCollection.php
+++ b/src/Metadata/Collection/TypeCollection.php
@@ -93,4 +93,18 @@ final class TypeCollection implements Countable, IteratorAggregate
 
         throw MetadataException::typeNotFound($name);
     }
+
+    /**
+     * @throws MetadataException
+     */
+    public function fetchByNameAndXmlNamespace(string $name, string $namespace): Type
+    {
+        foreach ($this->types as $type) {
+            if ($name === $type->getName() && $namespace === $type->getXsdType()->getXmlNamespace()) {
+                return $type;
+            }
+        }
+
+        throw MetadataException::typeNotFound($name);
+    }
 }

--- a/src/Metadata/Model/TypeMeta.php
+++ b/src/Metadata/Model/TypeMeta.php
@@ -56,6 +56,8 @@ final class TypeMeta
     private $isAttribute;
 
     /**
+     * Indicates the element value of an attribute-group.
+     *
      * @var bool|null
      */
     private $isElementValue;
@@ -69,6 +71,11 @@ final class TypeMeta
      * @var bool|null
      */
     private $isNullable;
+
+    /**
+     * @var bool|null
+     */
+    private $isElement;
 
     /**
      * @var bool|null
@@ -314,6 +321,22 @@ final class TypeMeta
     {
         $new = clone $this;
         $new->isSimple = $isSimple;
+
+        return $new;
+    }
+
+    /**
+     * @return Option<bool>
+     */
+    public function isElement(): Option
+    {
+        return from_nullable($this->isElement);
+    }
+
+    public function withIsElement(?bool $isElement): self
+    {
+        $new = clone $this;
+        $new->isElement = $isElement;
 
         return $new;
     }

--- a/tests/Unit/Metadata/Collection/TypeCollectionTest.php
+++ b/tests/Unit/Metadata/Collection/TypeCollectionTest.php
@@ -18,39 +18,52 @@ final class TypeCollectionTest extends TestCase
     protected function setUp(): void
     {
         $this->collection = new TypeCollection(
-            new Type(XsdType::create('Response'), new PropertyCollection())
+            new Type(XsdType::create('Response')->withXmlNamespace('http://namesapce'), new PropertyCollection())
         );
     }
 
-    
     public function test_it_can_iterate_over_types(): void
     {
         static::assertCount(1, $this->collection);
         static::assertSame([...$this->collection], $this->collection->map(static fn ($item) => $item));
     }
 
-    
     public function test_it_can_fetch_by_name(): void
     {
         $type = $this->collection->fetchFirstByName('Response');
         static::assertSame('Response', $type->getName());
     }
 
-    
     public function test_it_can_fail_fetching_by_name(): void
     {
         $this->expectException(MetadataException::class);
         $this->collection->fetchFirstByName('nope');
     }
 
-    
+    public function test_it_can_fetch_by_name_and_namespace(): void
+    {
+        $type = $this->collection->fetchByNameAndXmlNamespace('Response', 'http://namesapce');
+        static::assertSame('Response', $type->getName());
+    }
+
+    public function test_it_can_fail_fetching_by_name_and_namespace_invalid_name(): void
+    {
+        $this->expectException(MetadataException::class);
+        $this->collection->fetchByNameAndXmlNamespace('nope', 'http://namespace');
+    }
+
+    public function test_it_can_fail_fetching_by_name_and_namespace_invalid_namespace(): void
+    {
+        $this->expectException(MetadataException::class);
+        $this->collection->fetchByNameAndXmlNamespace('Response', 'http://invalid');
+    }
+
     public function test_it_can_reduce(): void
     {
         $result = $this->collection->reduce(static fn (int $i, Type $item) => $i + 1, 0);
         static::assertSame(1, $result);
     }
 
-    
     public function test_it_can_filter(): void
     {
         $result = $this->collection->filter(static fn (Type $type) => true);

--- a/tests/Unit/Metadata/Collection/TypeMetaTest.php
+++ b/tests/Unit/Metadata/Collection/TypeMetaTest.php
@@ -95,6 +95,13 @@ final class TypeMetaTest extends TestCase
         static::assertSame($value, $meta->isSimple()->unwrapOr(null));
     }
 
+    public function test_it_has_is_element()
+    {
+        $value = true;
+        $meta = (new TypeMeta())->withIsElement($value);
+        static::assertSame($value, $meta->isElement()->unwrapOr(null));
+    }
+
     public function test_it_has_is_local()
     {
         $value = true;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

* Adds `isElement` to type meta (useful for detecting if the value of an attribute group is an element or simply a value)
* Adds `TypeCollection::fetchByNameAndXmlNamespace()` for detecting an exact type (if namespace is known).