### PR TITLE
Add simple indicator to extend

### DIFF
--- a/src/Exception/DriverException.php
+++ b/src/Exception/DriverException.php
@@ -8,7 +8,7 @@ final class DriverException extends RuntimeException
     public static function partialException(string $class): self
     {
         return new self(
-            sprintf('The partial driver you are using, does not implement '.$class.'. Please use a different SOAP driver.')
+            'The partial driver you are using, does not implement '.$class.'. Please use a different SOAP driver.'
         );
     }
 }

--- a/src/Exception/TransportException.php
+++ b/src/Exception/TransportException.php
@@ -8,7 +8,7 @@ final class TransportException extends RuntimeException
     public static function noop(): self
     {
         return new self(
-            sprintf('The transport you are using is configured not to handle any requests. Please specify a different SOAP transport!')
+            'The transport you are using is configured not to handle any requests. Please specify a different SOAP transport!'
         );
     }
 }

--- a/src/Metadata/Model/TypeMeta.php
+++ b/src/Metadata/Model/TypeMeta.php
@@ -36,7 +36,7 @@ final class TypeMeta
     private $enums;
 
     /**
-     * @var array{type: non-empty-string, namespace: non-empty-string}|null
+     * @var array{type: non-empty-string, namespace: non-empty-string, isSimple ?: bool}|null
      */
     private $extends;
 
@@ -190,7 +190,7 @@ final class TypeMeta
     }
 
     /**
-     * @return Option<array{type: non-empty-string, namespace: non-empty-string}>
+     * @return Option<array{type: non-empty-string, namespace: non-empty-string, isSimple ?: bool}>
      */
     public function extends(): Option
     {
@@ -207,6 +207,7 @@ final class TypeMeta
             shape([
                 'type' => non_empty_string(),
                 'namespace' => non_empty_string(),
+                'isSimple' => optional(bool()),
             ], true)
         )->coerce($extends);
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Extend now takes an optional isSimple indicator that can be used to mark that the type extends a simple type.

```php
    public function withExtends(?array $extends): self
    {
        $new = clone $this;
        $new->extends = optional(
            shape([
                'type' => non_empty_string(),
                'namespace' => non_empty_string(),
                'isSimple' => optional(bool()),
            ], true)
        )->coerce($extends);

        return $new;
    }

```
