### PR TITLE
Add additional optional XML information fields on XsdType

### DIFF
--- a/src/Metadata/Model/XsdType.php
+++ b/src/Metadata/Model/XsdType.php
@@ -6,11 +6,54 @@ namespace Soap\Engine\Metadata\Model;
 
 final class XsdType
 {
+    /**
+     * The name of the current type.
+     */
     private string $name;
+
+    /**
+     * The expected PHP base type.
+     */
     private string $baseType = '';
 
+    /**
+     * The XML namespace of the linked XML type=""
+     * For example : a string element can be in a specific tns: <tns:x>stringValue</tns:x>
+     * But it is still a string (in xsd namespace)
+     */
     private string $xmlNamespace = '';
+
+    /**
+     * The XML namespace name of the linked XML type=""
+     * For example : a string element can be in a specific tns: <tns:x>stringValue</tns:x>
+     * But it is still a string (in xsd namespace)
+     */
     private string $xmlNamespaceName = '';
+
+    /**
+     * The name of the linked XML type=""
+     * For example: <element name="X" type="anyType" /> --> anyType
+     */
+    private string $xmlTypeName = '';
+
+    /**
+     * The name="" of the type. (Same as Type::name)
+     * For example: <element name="X" type="anyType" />
+     * The target node name would be X
+     */
+    private string $xmlTargetNodeName = '';
+
+    /**
+     * Contains the wrapping XML target namespace.
+     * For example : a string element can be in a specific tns: <tns:x>stringValue</tns:x>
+     */
+    private string $xmlTargetNamespace = '';
+
+    /**
+     * Contains the wrapping XML target namespace name.
+     * For example : a string element can be in a specific tns: <tns:x>stringValue</tns:x>
+     */
+    private string $xmlTargetNamespaceName = '';
 
     private TypeMeta $meta;
     private array $memberTypes = [];
@@ -29,7 +72,7 @@ final class XsdType
     public static function guess(string $name): self
     {
         return self::create($name)
-           ->withBaseType(self::convertBaseType($name, ''));
+            ->withBaseType(self::convertBaseType($name, ''));
     }
 
     /**
@@ -118,6 +161,26 @@ final class XsdType
         return $this->xmlNamespaceName;
     }
 
+    public function getXmlTargetNamespace(): string
+    {
+        return $this->xmlTargetNamespace;
+    }
+
+    public function getXmlTargetNamespaceName(): string
+    {
+        return $this->xmlTargetNamespaceName;
+    }
+
+    public function getXmlTypeName(): string
+    {
+        return $this->xmlTypeName;
+    }
+
+    public function getXmlTargetNodeName(): string
+    {
+        return $this->xmlTargetNodeName;
+    }
+
     public function withXmlNamespace(string $xmlNamespace): self
     {
         $new = clone $this;
@@ -130,6 +193,38 @@ final class XsdType
     {
         $new = clone $this;
         $new->xmlNamespaceName = $xmlNamespaceName;
+
+        return $new;
+    }
+
+    public function withXmlTargetNamespace(string $xmlTargetNamespace): self
+    {
+        $new = clone $this;
+        $new->xmlTargetNamespace = $xmlTargetNamespace;
+
+        return $new;
+    }
+
+    public function withXmlTargetNamespaceName(string $xmlTargetNamespaceName): self
+    {
+        $new = clone $this;
+        $new->xmlTargetNamespaceName = $xmlTargetNamespaceName;
+
+        return $new;
+    }
+
+    public function withXmlTargetNodeName(string $xmlTargetNodeName): self
+    {
+        $new = clone $this;
+        $new->xmlTargetNodeName = $xmlTargetNodeName;
+
+        return $new;
+    }
+
+    public function withXmlTypeName(string $xmlTypeName): self
+    {
+        $new = clone $this;
+        $new->xmlTypeName = $xmlTypeName;
 
         return $new;
     }

--- a/tests/Unit/Metadata/Model/XsdTypeTest.php
+++ b/tests/Unit/Metadata/Model/XsdTypeTest.php
@@ -18,10 +18,13 @@ final class XsdTypeTest extends TestCase
         static::assertSame('myType', $type->getBaseTypeOrFallbackToName());
         static::assertSame('', $type->getXmlNamespace());
         static::assertSame('', $type->getXmlNamespaceName());
+        static::assertSame('', $type->getXmlTargetNamespace());
+        static::assertSame('', $type->getXmlTargetNamespaceName());
+        static::assertSame('', $type->getXmlTargetNodeName());
+        static::assertSame('', $type->getXmlTypeName());
         static::assertSame('', $type->getBaseType());
         static::assertSame([], $type->getMemberTypes());
     }
-
 
     public function test_it_cannot_guess_unknown_types()
     {
@@ -29,7 +32,6 @@ final class XsdTypeTest extends TestCase
         static::assertSame('myType', $type->getName());
         static::assertSame('', $type->getBaseType());
     }
-
 
     public function test_it_can_guess_known_types()
     {
@@ -40,7 +42,6 @@ final class XsdTypeTest extends TestCase
         }
     }
 
-
     public function test_it_can_add_base_type()
     {
         $type = XsdType::create('myType')->withBaseType('baseType');
@@ -49,7 +50,6 @@ final class XsdTypeTest extends TestCase
         static::assertSame('baseType', $type->getBaseType());
         static::assertSame('baseType', $type->getBaseTypeOrFallbackToName());
     }
-
 
     public function test_it_can_add_known_base_type_and_move_actual_type_to_member_types()
     {
@@ -63,7 +63,6 @@ final class XsdTypeTest extends TestCase
         }
     }
 
-
     public function test_it_can_add_member_types()
     {
         $new = XsdType::create('myType')->withMemberTypes($types = ['type1', 'type2']);
@@ -71,7 +70,6 @@ final class XsdTypeTest extends TestCase
         static::assertSame('myType', $new->getName());
         static::assertSame($types, $new->getMemberTypes());
     }
-
 
     public function test_it_can_add_xml_namespace()
     {
@@ -81,7 +79,6 @@ final class XsdTypeTest extends TestCase
         static::assertSame($namespace, $new->getXmlNamespace());
     }
 
-
     public function test_it_can_add_xml_namespace_name()
     {
         $new = XsdType::create('myType')->withXmlNamespaceName($namespace = 'hello');
@@ -90,6 +87,37 @@ final class XsdTypeTest extends TestCase
         static::assertSame('hello', $new->getXmlNamespaceName());
     }
 
+    public function test_it_can_add_xml_target_namespace()
+    {
+        $new = XsdType::create('myType')->withXmlTargetNamespace($namespace = 'http://tns');
+
+        static::assertSame('myType', $new->getName());
+        static::assertSame($namespace, $new->getXmlTargetNamespace());
+    }
+
+    public function test_it_can_add_xml_target_namespace_name()
+    {
+        $new = XsdType::create('myType')->withXmlTargetNamespaceName($namespaceName = 'tns');
+
+        static::assertSame('myType', $new->getName());
+        static::assertSame($namespaceName, $new->getXmlTargetNamespaceName());
+    }
+
+    public function test_it_can_add_xml_node_name()
+    {
+        $new = XsdType::create('myType')->withXmlTargetNodeName($node = 'myTypeNodeName');
+
+        static::assertSame('myType', $new->getName());
+        static::assertSame($node, $new->getXmlTargetNodeName());
+    }
+
+    public function test_it_can_add_xml_type_name()
+    {
+        $new = XsdType::create('myType')->withXmlTypeName($node = 'myTypeTypeName');
+
+        static::assertSame('myType', $new->getName());
+        static::assertSame($node, $new->getXmlTypeName());
+    }
 
     public function test_it_can_add_meta()
     {
@@ -102,7 +130,6 @@ final class XsdTypeTest extends TestCase
         static::assertNotSame($type->getMeta(), $new->getMeta());
         static::assertSame(1, $new->getMeta()->minOccurs()->unwrapOr(0));
     }
-
 
     public function test_it_can_return_name_as_string()
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

Adds additional fields to the `XsdType` that can be used for mapping from and to XML:

```php
    /**
     * The XML namespace of the linked XML type=""
     * For example : a string element can be in a specific tns: <tns:x>stringValue</tns:x>
     * But it is still a string (in xsd namespace)
     */
    private string $xmlNamespace = '';

    /**
     * The XML namespace name of the linked XML type=""
     * For example : a string element can be in a specific tns: <tns:x>stringValue</tns:x>
     * But it is still a string (in xsd namespace)
     */
    private string $xmlNamespaceName = '';

    /**
     * The name of the linked XML type=""
     * For example: <element name="X" type="anyType" /> --> anyType
     */
    private string $xmlTypeName = '';

    /**
     * The name="" of the type. (Same as Type::name)
     * For example: <element name="X" type="anyType" />
     * The target node name would be X
     */
    private string $xmlTargetNodeName = '';

    /**
     * Contains the wrapping XML target namespace.
     * For example : a string element can be in a specific tns: <tns:x>stringValue</tns:x>
     */
    private string $xmlTargetNamespace = '';

    /**
     * Contains the wrapping XML target namespace name.
     * For example : a string element can be in a specific tns: <tns:x>stringValue</tns:x>
     */
    private string $xmlTargetNamespaceName = '';

```
