### PR TITLE
Allow empty enumeration strings

### DIFF
--- a/src/Metadata/Model/TypeMeta.php
+++ b/src/Metadata/Model/TypeMeta.php
@@ -11,6 +11,7 @@ use function Psl\Type\mixed_dict;
 use function Psl\Type\non_empty_string;
 use function Psl\Type\optional;
 use function Psl\Type\shape;
+use function Psl\Type\string;
 use function Psl\Type\vec;
 
 final class TypeMeta
@@ -31,7 +32,7 @@ final class TypeMeta
     private $docs;
 
     /**
-     * @var list<non-empty-string>|null
+     * @var list<string>|null
      */
     private $enums;
 
@@ -171,7 +172,7 @@ final class TypeMeta
     }
 
     /**
-     * @return Option<list<non-empty-string>>
+     * @return Option<list<string>>
      */
     public function enums(): Option
     {
@@ -184,7 +185,7 @@ final class TypeMeta
     public function withEnums(?array $enums): self
     {
         $new = clone $this;
-        $new->enums = optional(vec(non_empty_string()))->coerce($enums);
+        $new->enums = optional(vec(string()))->coerce($enums);
 
         return $new;
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

Fixes: https://github.com/phpro/soap-client/issues/506


```xml
<xs:simpleType name="EmptySimpleType">
    <xs:restriction base="xs:string">
      <xs:enumeration value=""/>
    </xs:restriction>
  </xs:simpleType>
```

