### PR TITLE
Find method by SOAP action

### DIFF
--- a/src/Metadata/Collection/MethodCollection.php
+++ b/src/Metadata/Collection/MethodCollection.php
@@ -64,4 +64,19 @@ final class MethodCollection implements Countable, IteratorAggregate
 
         throw MetadataException::methodNotFound($name);
     }
+
+    /**
+     * @throws MetadataException
+     */
+    public function fetchBySoapAction(string $soapAction): Method
+    {
+        foreach ($this->methods as $method) {
+            $meta = $method->getMeta();
+            if ($meta->action()->isSome() && $soapAction === $meta->action()->unwrap()) {
+                return $method;
+            }
+        }
+
+        throw MetadataException::methodNotFound($soapAction);
+    }
 }

--- a/tests/Unit/Metadata/Collection/MethodCollectionTest.php
+++ b/tests/Unit/Metadata/Collection/MethodCollectionTest.php
@@ -9,6 +9,7 @@ use Soap\Engine\Exception\MetadataException;
 use Soap\Engine\Metadata\Collection\MethodCollection;
 use Soap\Engine\Metadata\Collection\ParameterCollection;
 use Soap\Engine\Metadata\Model\Method;
+use Soap\Engine\Metadata\Model\MethodMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 
 final class MethodCollectionTest extends TestCase
@@ -18,11 +19,12 @@ final class MethodCollectionTest extends TestCase
     protected function setUp(): void
     {
         $this->collection = new MethodCollection(
-            new Method('hello', new ParameterCollection(), XsdType::create('Response'))
+            (new Method('hello', new ParameterCollection(), XsdType::create('Response')))->withMeta(
+                static fn (MethodMeta $meta) => $meta->withAction('uri:hello')
+            )
         );
     }
 
-    
     public function test_it_can_iterate_over_methods(): void
     {
         static::assertCount(1, $this->collection);
@@ -41,5 +43,17 @@ final class MethodCollectionTest extends TestCase
     {
         $this->expectException(MetadataException::class);
         $this->collection->fetchByName('nope');
+    }
+
+    public function test_it_can_fetch_by_soap_action(): void
+    {
+        $method = $this->collection->fetchBySoapAction('uri:hello');
+        static::assertSame('hello', $method->getName());
+    }
+
+    public function test_it_can_fail_fetching_by_soap_action(): void
+    {
+        $this->expectException(MetadataException::class);
+        $this->collection->fetchBySoapAction('uri:nope');
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Provides a way to find a method based on SoapAction:

```php
// The soap action can be detected from a PSR-7 request headers by using:
// https://github.com/php-soap/psr18-transport/blob/main/src/HttpBinding/SoapActionDetector.php
$soapAction = 'http://tempuri.org/Add';

$method = $metadata->getMethods()->fetchBySoapAction($soapAction),
```

This comes in handy for soap servers : https://github.com/php-soap/encoding/pull/32

