### PR TITLE
Replace azjezz/psl with php-standard-library/php-standard-library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-        "azjezz/psl": "^3.0 || ^4.0 || ^5.0",
+        "php-standard-library/php-standard-library": "^3.0 || ^4.0 || ^5.0 || ^6.0",
         "php-soap/xml": "^1.9.0"
     },
     "autoload-dev": {


### PR DESCRIPTION
## Summary
- Replace `azjezz/psl` with `php-standard-library/php-standard-library` (drop-in replacement)
- Add `^6.0` to the version constraint

## Context
Ref: phpro/soap-client#604

## Test plan
- [x] `composer validate` passes
- [x] `composer update` resolves successfully