### PR TITLE
Bump PHP 8.4 as minimum version and update dependencies

### DIFF
--- a/.github/workflows/analyzers.yaml
+++ b/.github/workflows/analyzers.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: ['8.3', '8.4', '8.5']
+                php-versions: ['8.4', '8.5']
                 composer-options: ['--ignore-platform-req=php+']
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: ['8.3', '8.4', '8.5']
+                php-versions: ['8.4', '8.5']
                 composer-options: ['--ignore-platform-req=php+']
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: ['8.3', '8.4', '8.5']
+                php-versions: ['8.4', '8.5']
                 composer-options: ['--ignore-platform-req=php+']
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,12 @@
         }
     ],
     "require": {
-        "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-        "php-standard-library/php-standard-library": "^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "php-soap/xml": "^1.9.0"
+        "php": "~8.4.0 || ~8.5.0",
+        "php-standard-library/dict": "^6.1",
+        "php-standard-library/foundation": "^6.1",
+        "php-standard-library/option": "^6.1",
+        "php-standard-library/type": "^6.1",
+        "php-soap/xml": "^1.10.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,7 +2,7 @@
 <psalm
     errorLevel="1"
     strictBinaryOperands="true"
-    phpVersion="8.1"
+    phpVersion="8.4"
     allowStringToStandInForClass="true"
     rememberPropertyAssignmentsAfterCall="false"
     skipChecksOnUnresolvableIncludes="false"
@@ -21,4 +21,10 @@
             <directory name="tests"/>
         </ignoreFiles>
     </projectFiles>
-<plugins><pluginClass class="Psl\Psalm\Plugin"/></plugins></psalm>
+    <stubs>
+        <file name="vendor/veewee/xml/stubs/DOM.phpstub" />
+    </stubs>
+    <plugins>
+        <pluginClass class="Psl\Psalm\Plugin"/>
+    </plugins>
+</psalm>


### PR DESCRIPTION
## Summary

- Bump minimum PHP version from 8.3 to 8.4
- Replace monolithic `php-standard-library/php-standard-library` with standalone PSL packages (`dict`, `foundation`, `option`, `type`) at `^6.1`
- Bump `php-soap/xml` to `^1.10.0` (pulls in `veewee/xml` `^4.9`)
- Update psalm `phpVersion` to `8.4` and add `veewee/xml` DOM stubs
- Remove PHP 8.3 from all GitHub Actions matrices

## Test plan

- [x] php-cs-fixer passes
- [x] psalm passes (no errors, 100% type inference)
- [x] phpunit passes (87 tests, 433 assertions)
- [x] Tests pass on `docphpro/php84` Docker image (PHP 8.4.19, libxml 2.9.14)